### PR TITLE
Overview

### DIFF
--- a/css/draggable.css
+++ b/css/draggable.css
@@ -1,9 +1,6 @@
 .column {
-    width: 30%;
-    min-height: 600px;
-    float: left;
-    margin-right: 1.5%;
-    margin-left: 1.5%;
+    min-height: 500px;
+    border-bottom: 1px solid #e9e9e9;
 }
 
 .portlet {

--- a/css/styles.css
+++ b/css/styles.css
@@ -218,6 +218,7 @@ footer .col-2 {
     border: 1px solid #e9e9e9;
     border-left: 0;
     padding: 15px 15px 15px 0;
+    overflow: auto;
 }
 
 .grant-panel {
@@ -230,7 +231,7 @@ footer .col-2 {
     display: inline-block;
     white-space: nowrap;
     overflow: hidden;
-    width: 10.5%;
+    width: 11.7%;
     text-overflow: ellipsis;
     padding-left: 2%;
 }
@@ -246,10 +247,12 @@ footer .col-2 {
 }
 
 .grant-content > div {
-    padding-right: 0;
     padding-left: 30px;
-    border: 1px solid #e9e9e9;
-    /*text-align: right;*/
+}
+
+.grant-content * .progress {
+    height: 10px;
+    margin-bottom: 10px;
 }
 
 /*

--- a/css/styles.css
+++ b/css/styles.css
@@ -189,11 +189,12 @@ footer .col-2 {
 
 .vert-panels {
     margin-top: 50px;
-    padding-left: 15%;
+    padding-left: 23px;
+    padding-right: 30px;
 }
 
-.vert-panels > div {
-    padding-left: 0;
+.panel-tabs > div {
+    padding-right: 0;
 }
 
 /* when using this class, child must be div for borders*/
@@ -216,7 +217,7 @@ footer .col-2 {
 .tab-left > div {
     border: 1px solid #e9e9e9;
     border-left: 0;
-    padding: 15px;
+    padding: 15px 15px 15px 0;
 }
 
 .grant-panel {
@@ -231,20 +232,24 @@ footer .col-2 {
     overflow: hidden;
     width: 10.5%;
     text-overflow: ellipsis;
+    padding-left: 2%;
 }
 
 .grant-info > a {
     border-bottom: 1px dotted #A30046;
 }
 
-.grant-content {
+.grant-content, .panel-tabs {
+    float: right;
     display: inline-block;
-    width: 88.9%;
+    width: 88%;
 }
 
 .grant-content > div {
     padding-right: 0;
+    padding-left: 30px;
     border: 1px solid #e9e9e9;
+    /*text-align: right;*/
 }
 
 /*

--- a/css/styles.css
+++ b/css/styles.css
@@ -187,43 +187,64 @@ footer .col-2 {
  ------------------------------------------------------------------------------------------
  */
 
-h4 > a {
-    border-bottom: 1px dotted #A30046;
+.vert-panels {
+    margin-top: 50px;
+    padding-left: 15%;
 }
 
 .vert-panels > div {
-    width: 20%;
-    display: inline-block;
-    margin-right: 1.5%;
-    float: right;
-    z-index: 50;
+    padding-left: 0;
 }
 
+/* when using this class, child must be div for borders*/
 .tab-top {
-    border-top: 8px solid #a30046 !important;
+    border-top: 8px solid #a30046;
+    padding: 0;
+}
+
+.tab-top > div {
+    border-left: 1px solid #e9e9e9;
+    border-right: 1px solid #e9e9e9;
+    padding: 7px 15px;
+}
+
+.tab-left {
+    border-left: 8px solid #a30046;
+    padding: 0;
+}
+
+.tab-left > div {
     border: 1px solid #e9e9e9;
+    border-left: 0;
     padding: 15px;
 }
 
-.grant-panels {
-    margin-top: -1px;
-}
-
-.grant-panels > div {
-    /*width: 99%;*/
-    border-left: 8px solid #a30046 !important;
-    border: 1px solid #e9e9e9;
+.grant-panel {
     display: block;
-    margin: 0 0.5% 5px 0.5%;
-    padding: 15px;
+    margin-bottom: 5px;
     z-index: 100;
 }
 
 .grant-info {
+    display: inline-block;
     white-space: nowrap;
     overflow: hidden;
-    width: 11%;
+    width: 10.5%;
     text-overflow: ellipsis;
+}
+
+.grant-info > a {
+    border-bottom: 1px dotted #A30046;
+}
+
+.grant-content {
+    display: inline-block;
+    width: 88.9%;
+}
+
+.grant-content > div {
+    padding-right: 0;
+    border: 1px solid #e9e9e9;
 }
 
 /*

--- a/detail.html
+++ b/detail.html
@@ -29,7 +29,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a id="brand" class="navbar-brand" href="#">Kanbosal</a>
+          <a id="brand" class="navbar-brand" href="overview">Kanbosal</a>
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">

--- a/overview.html
+++ b/overview.html
@@ -88,7 +88,6 @@
 
 <script src="javascript/handlebars-v4.0.4.js"></script>
 <script src="javascript/footer.js"></script>
-<script src="javascript/sidebar.js"></script>
 
 </body>
 </html>

--- a/overview.html
+++ b/overview.html
@@ -40,8 +40,6 @@
 
     <!-- grant panels can be color coded when process is complete -->
     <div id="content">
-      <div id="sidebar" class="toggled"></div>
-      <div><a id="menu-toggle" class="glyphicon glyphicon-menu-right large"></a></div>
       <div id="contentview" class="container-fluid toggled">
         <!-- <div id="overview-board"> -->
         <div class="container-fluid vert-panels">

--- a/overview.html
+++ b/overview.html
@@ -43,29 +43,31 @@
   <div id="content">
     <div id="contentview" class="container-fluid toggled">
       <div class="container-fluid vert-panels">
-        <div class="col-xs-3">
-          <div class="tab-top">
-            <div><h4>Research</h4></div>
+        <div class="panel-tabs">
+          <div class="col-xs-3">
+            <div class="tab-top">
+              <div><h4>Research</h4></div>
+            </div>
           </div>
-        </div>
-        <div class="col-xs-3">
-          <div class="tab-top">
-            <div><h4>Internal</h4></div>
+          <div class="col-xs-3">
+            <div class="tab-top">
+              <div><h4>Internal</h4></div>
+            </div>
           </div>
-        </div>
-        <div class="col-xs-3">
-          <div class="tab-top">
-            <div><h4>ASU</h4></div>
+          <div class="col-xs-3">
+            <div class="tab-top">
+              <div><h4>ASU</h4></div>
+            </div>
           </div>
-        </div>
-        <div class="col-xs-3">
-          <div class="tab-top">
-            <div><h4>Complete</h4></div>
+          <div class="col-xs-3">
+            <div class="tab-top">
+              <div><h4>Complete</h4></div>
+            </div>
           </div>
         </div>
       </div>
 
-      <div class="container-fluid grant-panels">
+      <div class="container-fluid">
         <div class="grant-panel tab-left">
           <div>
             <div class="grant-info">

--- a/overview.html
+++ b/overview.html
@@ -68,11 +68,13 @@
 
       <div class="container-fluid">
 
+<!-- make this container fill with template -->
 
         <div class="grant-panel tab-left">
           <div>
             <div class="grant-info">
-              <a href="detail" title="NSF Career">NSF Career</a>
+              <a href="detail" title="NSF Career">NSF Career</a><br>
+              <small>John Doe</small>
             </div>
             <div class="grant-content">
               <div class="col-xs-3">
@@ -159,7 +161,8 @@
         <div class="grant-panel tab-left">
           <div>
             <div class="grant-info">
-              <a href="detail" title="NSF Career Copy">NSF Career Copy</a>
+              <a href="detail" title="NSF Career Copy">NSF Career Copy</a><br>
+              <small>Jane Doe</small>
             </div>
             <div class="grant-content">
               <div class="col-xs-3">

--- a/overview.html
+++ b/overview.html
@@ -27,59 +27,68 @@
           <ul class="nav navbar-nav navbar-right">
             <li class="dropdown">
               <a href="#" class="dropdown-toggle profile-image" data-toggle="dropdown">
-                <img src="resources/square-facebook-64.png" class="img-circle special-image"><b class="caret"></b></a>
-                <ul class="dropdown-menu">
-                  <li><a href="#" onclick="signOut();"><i class="fa fa-sign-out"></i>Sign-out</a></li>
-                </ul>
+                <img src="resources/square-facebook-64.png" class="img-circle special-image"><b class="caret"></b>
               </a>
-            </li>
-          </ul>
+              <ul class="dropdown-menu">
+                <li><a href="#" onclick="signOut();"><i class="fa fa-sign-out"></i>Sign-out</a></li>
+              </ul>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <!-- grant panels can be color coded when process is complete -->
+  <div id="content">
+    <div id="contentview" class="container-fluid toggled">
+      <div class="container-fluid vert-panels">
+        <div class="col-xs-3">
+          <div class="tab-top">
+            <div><h4>Research</h4></div>
+          </div>
+        </div>
+        <div class="col-xs-3">
+          <div class="tab-top">
+            <div><h4>Internal</h4></div>
+          </div>
+        </div>
+        <div class="col-xs-3">
+          <div class="tab-top">
+            <div><h4>ASU</h4></div>
+          </div>
+        </div>
+        <div class="col-xs-3">
+          <div class="tab-top">
+            <div><h4>Complete</h4></div>
+          </div>
         </div>
       </div>
-    </nav>
 
-    <!-- grant panels can be color coded when process is complete -->
-    <div id="content">
-      <div id="contentview" class="container-fluid toggled">
-        <!-- <div id="overview-board"> -->
-        <div class="container-fluid vert-panels">
-          <div class="vert-panel tab-top">
-            <h4>Complete</h4>
-          </div>
-          <div class="vert-panel tab-top">
-            <h4>ASU</h4>
-          </div>
-          <div class="vert-panel tab-top">
-            <h4>Internal</h4>
-          </div>
-          <div class="vert-panel tab-top">
-            <h4>Research</h4>
-          </div>
-        </div>
-
-        <div id="grant-overview" class="container-fluid grant-panels">
-          <!-- this will eventually be dynamic with injection from jQuery -->
-          <div class="grant-panel">
+      <div class="container-fluid grant-panels">
+        <div class="grant-panel tab-left">
+          <div>
             <div class="grant-info">
               <a href="detail">NSF Career</a>
             </div>
-          </div>
-          <div class="grant-panel">
-            <div class="grant-info">
-              <a href="#">NSF S-STEM</a>
+            <div class="grant-content">
+              <div class="col-xs-3">test column content</div>
+              <div class="col-xs-3">test column content</div>
+              <div class="col-xs-3">test column content</div>
+              <div class="col-xs-3">test column content</div>
             </div>
           </div>
         </div>
-        <!-- </div> -->
       </div>
     </div>
-
-    <footer></footer>
   </div>
 
-  <script src="javascript/handlebars-v4.0.4.js"></script>
-  <script src="javascript/footer.js"></script>
-  <script src="javascript/sidebar.js"></script>
+  <footer></footer>
+</div>
+
+<script src="javascript/handlebars-v4.0.4.js"></script>
+<script src="javascript/footer.js"></script>
+<script src="javascript/sidebar.js"></script>
 
 </body>
 </html>

--- a/overview.html
+++ b/overview.html
@@ -39,7 +39,6 @@
     </div>
   </nav>
 
-  <!-- grant panels can be color coded when process is complete -->
   <div id="content">
     <div id="contentview" class="container-fluid toggled">
       <div class="container-fluid vert-panels">
@@ -68,19 +67,182 @@
       </div>
 
       <div class="container-fluid">
+
+
         <div class="grant-panel tab-left">
           <div>
             <div class="grant-info">
-              <a href="detail">NSF Career</a>
+              <a href="detail" title="NSF Career">NSF Career</a>
             </div>
             <div class="grant-content">
-              <div class="col-xs-3">test column content</div>
-              <div class="col-xs-3">test column content</div>
-              <div class="col-xs-3">test column content</div>
-              <div class="col-xs-3">test column content</div>
+              <div class="col-xs-3">
+                <div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 40%">
+                      <span class="sr-only">40% Complete (success)</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="width: 20%">
+                      <span class="sr-only">20% Complete</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
+                      <span class="sr-only">80% Complete (danger)</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xs-3">
+                <div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 40%">
+                      <span class="sr-only">40% Complete (success)</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="width: 20%">
+                      <span class="sr-only">20% Complete</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
+                      <span class="sr-only">80% Complete (danger)</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xs-3">
+                <div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 40%">
+                      <span class="sr-only">40% Complete (success)</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="width: 20%">
+                      <span class="sr-only">20% Complete</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
+                      <span class="sr-only">80% Complete (danger)</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xs-3">
+                <div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 40%">
+                      <span class="sr-only">40% Complete (success)</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="width: 20%">
+                      <span class="sr-only">20% Complete</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
+                      <span class="sr-only">80% Complete (danger)</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
+
+
+        <div class="grant-panel tab-left">
+          <div>
+            <div class="grant-info">
+              <a href="detail" title="NSF Career Copy">NSF Career Copy</a>
+            </div>
+            <div class="grant-content">
+              <div class="col-xs-3">
+                <div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 40%">
+                      <span class="sr-only">40% Complete (success)</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="width: 20%">
+                      <span class="sr-only">20% Complete</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
+                      <span class="sr-only">80% Complete (danger)</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xs-3">
+                <div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 40%">
+                      <span class="sr-only">40% Complete (success)</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="width: 20%">
+                      <span class="sr-only">20% Complete</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
+                      <span class="sr-only">80% Complete (danger)</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xs-3">
+                <div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 40%">
+                      <span class="sr-only">40% Complete (success)</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="width: 20%">
+                      <span class="sr-only">20% Complete</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
+                      <span class="sr-only">80% Complete (danger)</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-xs-3">
+                <div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 40%">
+                      <span class="sr-only">40% Complete (success)</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" style="width: 20%">
+                      <span class="sr-only">20% Complete</span>
+                    </div>
+                  </div>
+                  <div class="progress">
+                    <div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%">
+                      <span class="sr-only">80% Complete (danger)</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+
       </div>
     </div>
   </div>

--- a/templates/full_card.html
+++ b/templates/full_card.html
@@ -1,33 +1,37 @@
 {{#if Grant_Columns}}
   {{#each Grant_Columns}}
-  <div class="column collapsed tab-top">
-    <h4>{{Column_Name}}</h4>
-    {{#if Cards}}
-      {{#each Cards}}
-        <div class="portlet panel panel-default">
-          <div class="portlet-header panel-heading" data-toggle="modal" data-target="#{{Modal_ID}}"><h3 class="panel-title">{{Card_Name}}</h3></div>
-          {{#compare ../Column_Name "!=" "To Do"}}
-            <div class="portlet-content panel-body">
-              {{#if Document_Link}}
-                <a target="_blank" href="{{Document_Link}}"><span class="glyphicon glyphicon-file card-icons"></span></a>
-              {{/if}}
-              {{#compare ../Column_Name "Complete"}}
-                {{#if Tag_List}}
-                  {{#each Tag_List}}
-                    <span class="label label-success card-icons">{{this}}</span>
-                  {{/each}}
-                {{/if}}
+  <div class="col-xs-4">
+    <div class="tab-top">
+      <div class="column">
+        <h4>{{Column_Name}}</h4>
+        {{#if Cards}}
+          {{#each Cards}}
+            <div class="portlet panel panel-default">
+              <div class="portlet-header panel-heading" data-toggle="modal" data-target="#{{Modal_ID}}"><h3 class="panel-title">{{Card_Name}}</h3></div>
+              {{#compare ../Column_Name "!=" "To Do"}}
+                <div class="portlet-content panel-body">
+                  {{#if Document_Link}}
+                    <a target="_blank" href="{{Document_Link}}"><span class="glyphicon glyphicon-file card-icons"></span></a>
+                  {{/if}}
+                  {{#compare ../Column_Name "Complete"}}
+                    {{#if Tag_List}}
+                      {{#each Tag_List}}
+                        <span class="label label-success card-icons">{{this}}</span>
+                      {{/each}}
+                    {{/if}}
+                  {{/compare}}
+                  {{#if Assigned_People}}
+                    {{#each Assigned_People}}
+                      <span class="glyphicon glyphicon-user assigned-person card-icons"></span>
+                    {{/each}}
+                  {{/if}}
+                </div>
               {{/compare}}
-              {{#if Assigned_People}}
-                {{#each Assigned_People}}
-                  <span class="glyphicon glyphicon-user assigned-person card-icons"></span>
-                {{/each}}
-              {{/if}}
             </div>
-          {{/compare}}
-        </div>
-      {{/each}}
-    {{/if}}
+          {{/each}}
+        {{/if}}
+      </div>
+    </div>
   </div>
   {{/each}}
 {{/if}}


### PR DESCRIPTION
Updated styling for overview tabs (also used in detail page, so also modified some of that), also a **very** loose demo of what the slimmed down overview would kind of have (basically, progress bars -- will be integrated with bootstrap's tooltip or popover).

In her original concept diagram, she wanted us to show all the grant components flowing across the sections. Now, to slim it down (still working on it), the components can be icons or something small, which can have its visibility toggled (bootstrap's collapsible), and some other data that we decide to show on it.
